### PR TITLE
Expose SPA Callback Function(on) and Export SPA Models from @asgardeo/auth-spa

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,8 +62,9 @@ module.exports = {
                     "allowPrivateClassPropertyAccess": true
                 }
             ],
-            "no-shadow": "off",
-            "@typescript-eslint/no-shadow": ["error"]
+            "@typescript-eslint/no-shadow": ["error"],
+            "@typescript-eslint/brace-style": ["error", "stroustrup"],
+            "padded-blocks": ["error", "never"]
         }
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,7 +61,9 @@ module.exports = {
                 {
                     "allowPrivateClassPropertyAccess": true
                 }
-            ]
+            ],
+            "no-shadow": "off",
+            "@typescript-eslint/no-shadow": ["error"]
         }
     },
     {

--- a/angular.json
+++ b/angular.json
@@ -100,7 +100,6 @@
                     "builder": "@angular-devkit/build-angular:dev-server",
                     "options": {
                         "browserTarget": "playground:build",
-                        "port": 3000,
                         "ssl": true
                     },
                     "configurations": {

--- a/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { BasicUserInfo } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service";
@@ -36,7 +36,8 @@ describe("AsgardeoSignInRedirectComponent", () => {
     beforeEach(async () => {
         authServiceStub = {
             signIn: () => Promise.resolve({} as BasicUserInfo),
-            isAuthenticated: () => Promise.resolve(true)
+            isAuthenticated: () => Promise.resolve(true),
+            on: () => Promise.resolve()
         };
 
         navigatorServiceStub = {
@@ -79,16 +80,4 @@ describe("AsgardeoSignInRedirectComponent", () => {
 
         expect(signInSpy).toHaveBeenCalled();
     });
-
-    it("should redirect back after signIn resolves", fakeAsync(() => {
-        const getRedirectUrlSpy = spyOn(navigatorService, "getRedirectUrl").and.returnValue("fakeRedirectUrl");
-        const navigateByUrlSpy = spyOn(navigatorService, "navigateByUrl");
-        spyOn(authService, "isAuthenticated").and.resolveTo(false);
-
-        fixture.detectChanges();
-        tick();
-
-        expect(getRedirectUrlSpy).toHaveBeenCalled();
-        expect(navigateByUrlSpy).toHaveBeenCalledWith("fakeRedirectUrl");
-    }));
 });

--- a/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
@@ -18,6 +18,7 @@
  */
 
 import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { BasicUserInfo } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service";
 import { AsgardeoSignInRedirectComponent } from "./asgardeo-sign-in-redirect.component";
@@ -35,12 +36,12 @@ describe("AsgardeoSignInRedirectComponent", () => {
     beforeEach(async () => {
 
         authServiceStub = {
-            signIn: () => Promise.resolve(),
+            signIn: () => Promise.resolve({} as BasicUserInfo),
             isAuthenticated: () => Promise.resolve(true)
         };
 
         navigatorServiceStub = {
-            navigateByUrl: (params) => Promise.resolve(true),
+            navigateByUrl: () => Promise.resolve(true),
             getRedirectUrl: () => "fakeRedirectUrl"
         };
 
@@ -73,7 +74,7 @@ describe("AsgardeoSignInRedirectComponent", () => {
     });
 
     it("should call signIn", () => {
-        const signInSpy = spyOn(authService, "signIn").and.resolveTo("fakeSignIn");
+        const signInSpy = spyOn(authService, "signIn").and.resolveTo({ "username": "fakeUser" } as BasicUserInfo);
 
         fixture.detectChanges();
 

--- a/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
@@ -34,7 +34,6 @@ describe("AsgardeoSignInRedirectComponent", () => {
     let navigatorServiceStub: Partial<AsgardeoNavigatorService>;
 
     beforeEach(async () => {
-
         authServiceStub = {
             signIn: () => Promise.resolve({} as BasicUserInfo),
             isAuthenticated: () => Promise.resolve(true)
@@ -74,7 +73,7 @@ describe("AsgardeoSignInRedirectComponent", () => {
     });
 
     it("should call signIn", () => {
-        const signInSpy = spyOn(authService, "signIn").and.resolveTo({ "username": "fakeUser" } as BasicUserInfo);
+        const signInSpy = spyOn(authService, "signIn").and.resolveTo({} as BasicUserInfo);
 
         fixture.detectChanges();
 

--- a/lib/src/components/asgardeo-sign-in-redirect.component.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.ts
@@ -27,7 +27,6 @@ import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service
     template: ""
 })
 export class AsgardeoSignInRedirectComponent implements OnInit {
-
     constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) {
         this.auth.on(Hooks.SignIn, () => {
             this.navigator.navigateByUrl(this.navigator.getRedirectUrl());

--- a/lib/src/components/asgardeo-sign-in-redirect.component.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.ts
@@ -27,13 +27,12 @@ import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service
     template: ""
 })
 export class AsgardeoSignInRedirectComponent implements OnInit {
-    constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) {
+    constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) { }
+
+    ngOnInit(): void {
         this.auth.on(Hooks.SignIn, () => {
             this.navigator.navigateByUrl(this.navigator.getRedirectUrl());
         });
-    }
-
-    ngOnInit(): void {
         this.auth.signIn();
     }
 }

--- a/lib/src/components/asgardeo-sign-in-redirect.component.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.ts
@@ -18,6 +18,7 @@
  */
 
 import { Component, OnInit } from "@angular/core";
+import { Hooks } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service";
 
@@ -27,11 +28,13 @@ import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service
 })
 export class AsgardeoSignInRedirectComponent implements OnInit {
 
-    constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) { }
-
-    ngOnInit(): void {
-        this.auth.signIn().then(() => {
+    constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) {
+        this.auth.on(Hooks.SignIn, () => {
             this.navigator.navigateByUrl(this.navigator.getRedirectUrl());
         });
+    }
+
+    ngOnInit(): void {
+        this.auth.signIn();
     }
 }

--- a/lib/src/guards/asgardeo-auth.guard.ts
+++ b/lib/src/guards/asgardeo-auth.guard.ts
@@ -25,7 +25,6 @@ import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
     providedIn: "root"
 })
 export class AsgardeoAuthGuard implements CanActivate, CanActivateChild {
-
     constructor(private auth: AsgardeoAuthService) { }
 
     async canActivate(): Promise<boolean> {

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -20,5 +20,7 @@
 export {
     BasicUserInfo,
     DecodedIDTokenPayload,
-    OIDCEndpoints
+    Hooks,
+    OIDCEndpoints,
+    SignInConfig
 } from "@asgardeo/auth-spa";

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -17,13 +17,8 @@
  *
  */
 
-/*
- * Public API Surface of @asgardeo/auth-angular
- */
-
-export * from "./asgardeo-auth.module";
-export * from "./components/asgardeo-sign-in-redirect.component";
-export * from "./guards/asgardeo-auth.guard";
-export * from "./models/asgardeo-config.interface";
-export * from "./models/asgardeo-spa.models";
-export * from "./services/asgardeo-auth.service";
+export {
+    BasicUserInfo,
+    DecodedIDTokenPayload,
+    OIDCEndpoints
+} from "@asgardeo/auth-spa";

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -20,7 +20,13 @@
 export {
     BasicUserInfo,
     DecodedIDTokenPayload,
-    Hooks,
     OIDCEndpoints,
     SignInConfig
 } from "@asgardeo/auth-spa";
+
+/* eslint-disable */
+export enum Hooks {
+    SignIn = "sign-in",
+    SignOut = "sign-out",
+    RevokeAccessToken = "revoke-access-token"
+}

--- a/lib/src/services/asgardeo-auth.service.spec.ts
+++ b/lib/src/services/asgardeo-auth.service.spec.ts
@@ -60,7 +60,6 @@ describe("AsgardeoAuthService", () => {
     it("should be created", () => {
         expect(service).toBeTruthy();
         expect(service["auth"]).toBeDefined();
-        expect();
     });
 
     it("should call auth.signIn when signIn is called", () => {

--- a/lib/src/services/asgardeo-auth.service.spec.ts
+++ b/lib/src/services/asgardeo-auth.service.spec.ts
@@ -32,7 +32,6 @@ describe("AsgardeoAuthService", () => {
     let navigatorServiceStub: Partial<AsgardeoNavigatorService>;
 
     beforeEach(() => {
-
         navigatorServiceStub = {
             navigateByUrl: () => Promise.resolve(true),
             setRedirectUrl: () => "",

--- a/lib/src/services/asgardeo-auth.service.spec.ts
+++ b/lib/src/services/asgardeo-auth.service.spec.ts
@@ -20,6 +20,7 @@
 import { TestBed } from "@angular/core/testing";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
+import { Hooks } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "./asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "./asgardeo-navigator.service";
 
@@ -33,7 +34,7 @@ describe("AsgardeoAuthService", () => {
     beforeEach(() => {
 
         navigatorServiceStub = {
-            navigateByUrl: (params) => Promise.resolve(true),
+            navigateByUrl: () => Promise.resolve(true),
             setRedirectUrl: () => "",
             getCurrentRoute: () => "fakeUrl",
             getRouteWithoutParams: () => "fakeRoute"
@@ -119,6 +120,14 @@ describe("AsgardeoAuthService", () => {
         expect(getAccessTokenSpy).toHaveBeenCalled();
     });
 
+    it("should call auth.getIDToken when getIDToken is called", () => {
+        const getIDTokenSpy = spyOn(service["auth"], "getIDToken");
+
+        service.getIDToken();
+
+        expect(getIDTokenSpy).toHaveBeenCalled();
+    });
+
     it("should call auth.getDecodedIDToken when getDecodedIDToken is called", () => {
         const getDecodedIDTokenSpy = spyOn(service["auth"], "getDecodedIDToken");
 
@@ -149,5 +158,13 @@ describe("AsgardeoAuthService", () => {
         service.revokeAccessToken();
 
         expect(revokeAccessTokenSpy).toHaveBeenCalled();
+    });
+
+    it("should call auth.on when on is called", () => {
+        const onSpy = spyOn(service["auth"], "on");
+
+        service.on(Hooks.SignIn, () => { });
+
+        expect(onSpy).toHaveBeenCalled();
     });
 });

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -18,9 +18,10 @@
  */
 
 import { Inject, Injectable } from "@angular/core";
-import { AsgardeoSPAClient, BasicUserInfo, DecodedIDTokenPayload, OIDCEndpoints } from "@asgardeo/auth-spa";
+import { AsgardeoSPAClient } from "@asgardeo/auth-spa";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
+import { BasicUserInfo, DecodedIDTokenPayload, OIDCEndpoints } from "../models/asgardeo-spa.models";
 import { AsgardeoNavigatorService } from "./asgardeo-navigator.service";
 
 @Injectable({

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -41,7 +41,7 @@ export class AsgardeoAuthService {
         authorizationCode?: string,
         sessionState?: string
     ) {
-        this.auth.signIn(config, authorizationCode, sessionState);
+        return this.auth.signIn(config, authorizationCode, sessionState);
     };
 
     signInWithRedirect(): Promise<boolean> {
@@ -87,9 +87,7 @@ export class AsgardeoAuthService {
     }
 
     on(hook: Hooks, callback: (response?: any) => void): Promise<void> {
-        if (hook !== Hooks.CustomGrant) {
-            return this.auth.on(hook, callback);
-        }
+        return this.auth.on(hook, callback);
     };
 
     private intializeSPAClient() {

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -21,7 +21,7 @@ import { Inject, Injectable } from "@angular/core";
 import { AsgardeoSPAClient } from "@asgardeo/auth-spa";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
-import { BasicUserInfo, DecodedIDTokenPayload, OIDCEndpoints } from "../models/asgardeo-spa.models";
+import { BasicUserInfo, DecodedIDTokenPayload, Hooks, OIDCEndpoints, SignInConfig } from "../models/asgardeo-spa.models";
 import { AsgardeoNavigatorService } from "./asgardeo-navigator.service";
 
 @Injectable({
@@ -36,9 +36,13 @@ export class AsgardeoAuthService {
         this.intializeSPAClient();
     }
 
-    signIn(): Promise<BasicUserInfo> {
-        return this.auth.signIn();
-    }
+    signIn(
+        config?: SignInConfig,
+        authorizationCode?: string,
+        sessionState?: string
+    ) {
+        this.auth.signIn(config, authorizationCode, sessionState);
+    };
 
     signInWithRedirect(): Promise<boolean> {
         this.navigator.setRedirectUrl();
@@ -81,6 +85,12 @@ export class AsgardeoAuthService {
     revokeAccessToken(): Promise<boolean> {
         return this.auth.revokeAccessToken();
     }
+
+    on(hook: Hooks, callback: (response?: any) => void): Promise<void> {
+        if (hook !== Hooks.CustomGrant) {
+            return this.auth.on(hook, callback);
+        }
+    };
 
     private intializeSPAClient() {
         this.auth = AsgardeoSPAClient.getInstance();

--- a/lib/src/services/asgardeo-navigator.service.ts
+++ b/lib/src/services/asgardeo-navigator.service.ts
@@ -24,7 +24,6 @@ import { Router } from "@angular/router";
     providedIn: "root"
 })
 export class AsgardeoNavigatorService {
-
     private readonly router: Router;
 
     constructor(injector: Injector) {

--- a/playground/src/app/app.component.html
+++ b/playground/src/app/app.component.html
@@ -57,7 +57,7 @@ under the License.
     <footer class="mast-foot mt-auto">
         <div class="inner">
             <p>
-                @2020
+                @2021
                 <a
                     href="https://wso2.com"
                     target="_blank"

--- a/playground/src/app/app.module.ts
+++ b/playground/src/app/app.module.ts
@@ -35,8 +35,8 @@ import { ProfileComponent } from "./profile/profile.component";
         BrowserModule,
         AppRoutingModule,
         AsgardeoAuthModule.forRoot({
-            signInRedirectURL: "https://localhost:3000/signin/redirect",
-            signOutRedirectURL: "https://localhost:3000",
+            signInRedirectURL: "https://localhost:4200/signin/redirect",
+            signOutRedirectURL: "https://localhost:4200",
             clientID: "",
             serverOrigin: ""
         })

--- a/playground/src/app/home/home.component.spec.ts
+++ b/playground/src/app/home/home.component.spec.ts
@@ -18,15 +18,31 @@
  */
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AsgardeoAuthService, BasicUserInfo } from "@asgardeo/auth-angular";
 import { HomeComponent } from "./home.component";
 
 describe("HomeComponent", () => {
     let component: HomeComponent;
     let fixture: ComponentFixture<HomeComponent>;
 
+    let authService: AsgardeoAuthService;
+    let authServiceStub: Partial<AsgardeoAuthService>;
+
+    authServiceStub = {
+        signIn: () => Promise.resolve({} as BasicUserInfo),
+        isAuthenticated: () => Promise.resolve(true),
+        on: () => Promise.resolve()
+    };
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [HomeComponent]
+            declarations: [HomeComponent],
+            providers: [
+                {
+                    provide: AsgardeoAuthService,
+                    useValue: authServiceStub
+                }
+            ]
         })
             .compileComponents();
     });
@@ -34,6 +50,8 @@ describe("HomeComponent", () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(HomeComponent);
         component = fixture.componentInstance;
+
+        authService = TestBed.inject(AsgardeoAuthService);
         fixture.detectChanges();
     });
 

--- a/playground/src/app/home/home.component.spec.ts
+++ b/playground/src/app/home/home.component.spec.ts
@@ -28,13 +28,13 @@ describe("HomeComponent", () => {
     let authService: AsgardeoAuthService;
     let authServiceStub: Partial<AsgardeoAuthService>;
 
-    authServiceStub = {
-        signIn: () => Promise.resolve({} as BasicUserInfo),
-        isAuthenticated: () => Promise.resolve(true),
-        on: () => Promise.resolve()
-    };
-
     beforeEach(async () => {
+        authServiceStub = {
+            signIn: () => Promise.resolve({} as BasicUserInfo),
+            isAuthenticated: () => Promise.resolve(true),
+            on: () => Promise.resolve()
+        };
+
         await TestBed.configureTestingModule({
             declarations: [HomeComponent],
             providers: [

--- a/playground/src/app/home/home.component.ts
+++ b/playground/src/app/home/home.component.ts
@@ -18,7 +18,7 @@
  */
 
 import { Component, OnInit } from "@angular/core";
-import { AsgardeoAuthService } from "@asgardeo/auth-angular";
+import { AsgardeoAuthService, Hooks } from "@asgardeo/auth-angular";
 
 @Component({
     selector: "app-home",
@@ -28,7 +28,11 @@ import { AsgardeoAuthService } from "@asgardeo/auth-angular";
 export class HomeComponent implements OnInit {
     isAuthenticated = false;
 
-    constructor(private auth: AsgardeoAuthService) { }
+    constructor(private auth: AsgardeoAuthService) {
+        this.auth.on(Hooks.SignOut, () => {
+            console.log("You signed out!!!");
+        });
+    }
 
     ngOnInit() {
         this.auth.isAuthenticated().then((status) => {

--- a/playground/src/app/profile/profile.component.html
+++ b/playground/src/app/profile/profile.component.html
@@ -31,17 +31,24 @@
             style="width: fit-content;"
         >
             <div class="card-header">
-                <h3>{{userInfo.displayName}}</h3>
+                <h3>{{userInfo.username}}</h3>
             </div>
             <div
                 class="card-body"
                 style="text-align: left;"
             >
-                <li>Access Token - {{accessToken}}</li>
-                <!-- <li>Email - {{userInfo.email}}</li> -->
-                <li>Username - {{userInfo.username}}</li>
-                <li>Allowed Scopes - {{userInfo.allowedScopes}}</li>
-                <li>Tenant Domain - {{userInfo.tenantDomain}}</li>
+                <table>
+                    <tr>
+                        <td>accessToken</td>
+                        <td> - </td>
+                        <td>{{accessToken}}</td>
+                    </tr>
+                    <tr *ngFor="let item of userInfo | keyvalue">
+                        <td>{{item.key}}</td>
+                        <td> - </td>
+                        <td>{{item.value}}</td>
+                    </tr>
+                </table>
             </div>
         </div>
     </ng-template>

--- a/playground/src/app/profile/profile.component.spec.ts
+++ b/playground/src/app/profile/profile.component.spec.ts
@@ -28,12 +28,12 @@ describe("ProfileComponent", () => {
     let authService: AsgardeoAuthService;
     let authServiceStub: Partial<AsgardeoAuthService>;
 
-    authServiceStub = {
-        signIn: () => Promise.resolve({} as BasicUserInfo),
-        isAuthenticated: () => Promise.resolve(true)
-    };
-
     beforeEach(async () => {
+        authServiceStub = {
+            signIn: () => Promise.resolve({} as BasicUserInfo),
+            isAuthenticated: () => Promise.resolve(true)
+        };
+
         await TestBed.configureTestingModule({
             declarations: [ProfileComponent],
             providers: [

--- a/playground/src/app/profile/profile.component.spec.ts
+++ b/playground/src/app/profile/profile.component.spec.ts
@@ -18,15 +18,30 @@
  */
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AsgardeoAuthService, BasicUserInfo } from "@asgardeo/auth-angular";
 import { ProfileComponent } from "./profile.component";
 
 describe("ProfileComponent", () => {
     let component: ProfileComponent;
     let fixture: ComponentFixture<ProfileComponent>;
 
+    let authService: AsgardeoAuthService;
+    let authServiceStub: Partial<AsgardeoAuthService>;
+
+    authServiceStub = {
+        signIn: () => Promise.resolve({} as BasicUserInfo),
+        isAuthenticated: () => Promise.resolve(true)
+    };
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [ProfileComponent]
+            declarations: [ProfileComponent],
+            providers: [
+                {
+                    provide: AsgardeoAuthService,
+                    useValue: authServiceStub
+                }
+            ]
         })
             .compileComponents();
     });
@@ -34,6 +49,8 @@ describe("ProfileComponent", () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ProfileComponent);
         component = fixture.componentInstance;
+
+        authService = TestBed.inject(AsgardeoAuthService);
         fixture.detectChanges();
     });
 


### PR DESCRIPTION
## Purpose

- Expose [`on`](https://github.com/asgardeo/asgardeo-auth-spa-sdk#on) callback method of @asgardeo/auth-spa
- Expose `sign-in`, `sign-out` and `revoke-access-token` hooks
- Re export @asgardeo/auth-spa [models](https://github.com/asgardeo/asgardeo-auth-spa-sdk#Models)
- Update unit tests

## Goals

- Closes #69