### PR TITLE
Add a HTTP Interceptor and Expose httpRequest Functions from @asgardeo/auth-spa

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,7 +64,8 @@ module.exports = {
             ],
             "@typescript-eslint/no-shadow": ["error"],
             "@typescript-eslint/brace-style": ["error", "stroustrup"],
-            "padded-blocks": ["error", "never"]
+            "padded-blocks": ["error", "never"],
+            "newline-before-return": ["error"]
         }
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,8 +62,9 @@ module.exports = {
                     "allowPrivateClassPropertyAccess": true
                 }
             ],
-            "no-shadow": "off",
-            "@typescript-eslint/no-shadow": ["error"]
+            "@typescript-eslint/no-shadow": ["error"],
+            "@typescript-eslint/brace-style": ["error", "stroustrup"],
+            "padded-blocks": ["error", "never"]
         }
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,7 +61,9 @@ module.exports = {
                 {
                     "allowPrivateClassPropertyAccess": true
                 }
-            ]
+            ],
+            "no-shadow": "off",
+            "@typescript-eslint/no-shadow": ["error"]
         }
     },
     {

--- a/angular.json
+++ b/angular.json
@@ -100,7 +100,6 @@
                     "builder": "@angular-devkit/build-angular:dev-server",
                     "options": {
                         "browserTarget": "playground:build",
-                        "port": 3000,
                         "ssl": true
                     },
                     "configurations": {

--- a/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
@@ -17,7 +17,7 @@
  *
  */
 
-import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { BasicUserInfo } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service";
@@ -36,7 +36,8 @@ describe("AsgardeoSignInRedirectComponent", () => {
     beforeEach(async () => {
         authServiceStub = {
             signIn: () => Promise.resolve({} as BasicUserInfo),
-            isAuthenticated: () => Promise.resolve(true)
+            isAuthenticated: () => Promise.resolve(true),
+            on: () => Promise.resolve()
         };
 
         navigatorServiceStub = {
@@ -79,16 +80,4 @@ describe("AsgardeoSignInRedirectComponent", () => {
 
         expect(signInSpy).toHaveBeenCalled();
     });
-
-    it("should redirect back after signIn resolves", fakeAsync(() => {
-        const getRedirectUrlSpy = spyOn(navigatorService, "getRedirectUrl").and.returnValue("fakeRedirectUrl");
-        const navigateByUrlSpy = spyOn(navigatorService, "navigateByUrl");
-        spyOn(authService, "isAuthenticated").and.resolveTo(false);
-
-        fixture.detectChanges();
-        tick();
-
-        expect(getRedirectUrlSpy).toHaveBeenCalled();
-        expect(navigateByUrlSpy).toHaveBeenCalledWith("fakeRedirectUrl");
-    }));
 });

--- a/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
@@ -18,6 +18,7 @@
  */
 
 import { ComponentFixture, fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { BasicUserInfo } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service";
 import { AsgardeoSignInRedirectComponent } from "./asgardeo-sign-in-redirect.component";
@@ -35,12 +36,12 @@ describe("AsgardeoSignInRedirectComponent", () => {
     beforeEach(async () => {
 
         authServiceStub = {
-            signIn: () => Promise.resolve(),
+            signIn: () => Promise.resolve({} as BasicUserInfo),
             isAuthenticated: () => Promise.resolve(true)
         };
 
         navigatorServiceStub = {
-            navigateByUrl: (params) => Promise.resolve(true),
+            navigateByUrl: () => Promise.resolve(true),
             getRedirectUrl: () => "fakeRedirectUrl"
         };
 
@@ -73,7 +74,7 @@ describe("AsgardeoSignInRedirectComponent", () => {
     });
 
     it("should call signIn", () => {
-        const signInSpy = spyOn(authService, "signIn").and.resolveTo("fakeSignIn");
+        const signInSpy = spyOn(authService, "signIn").and.resolveTo({ "username": "fakeUser" } as BasicUserInfo);
 
         fixture.detectChanges();
 

--- a/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.spec.ts
@@ -34,7 +34,6 @@ describe("AsgardeoSignInRedirectComponent", () => {
     let navigatorServiceStub: Partial<AsgardeoNavigatorService>;
 
     beforeEach(async () => {
-
         authServiceStub = {
             signIn: () => Promise.resolve({} as BasicUserInfo),
             isAuthenticated: () => Promise.resolve(true)
@@ -74,7 +73,7 @@ describe("AsgardeoSignInRedirectComponent", () => {
     });
 
     it("should call signIn", () => {
-        const signInSpy = spyOn(authService, "signIn").and.resolveTo({ "username": "fakeUser" } as BasicUserInfo);
+        const signInSpy = spyOn(authService, "signIn").and.resolveTo({} as BasicUserInfo);
 
         fixture.detectChanges();
 

--- a/lib/src/components/asgardeo-sign-in-redirect.component.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.ts
@@ -27,7 +27,6 @@ import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service
     template: ""
 })
 export class AsgardeoSignInRedirectComponent implements OnInit {
-
     constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) {
         this.auth.on(Hooks.SignIn, () => {
             this.navigator.navigateByUrl(this.navigator.getRedirectUrl());

--- a/lib/src/components/asgardeo-sign-in-redirect.component.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.ts
@@ -27,13 +27,12 @@ import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service
     template: ""
 })
 export class AsgardeoSignInRedirectComponent implements OnInit {
-    constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) {
+    constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) { }
+
+    ngOnInit(): void {
         this.auth.on(Hooks.SignIn, () => {
             this.navigator.navigateByUrl(this.navigator.getRedirectUrl());
         });
-    }
-
-    ngOnInit(): void {
         this.auth.signIn();
     }
 }

--- a/lib/src/components/asgardeo-sign-in-redirect.component.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.ts
@@ -18,6 +18,7 @@
  */
 
 import { Component, OnInit } from "@angular/core";
+import { Hooks } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service";
 
@@ -27,11 +28,13 @@ import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service
 })
 export class AsgardeoSignInRedirectComponent implements OnInit {
 
-    constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) { }
-
-    ngOnInit(): void {
-        this.auth.signIn().then(() => {
+    constructor(private auth: AsgardeoAuthService, private navigator: AsgardeoNavigatorService) {
+        this.auth.on(Hooks.SignIn, () => {
             this.navigator.navigateByUrl(this.navigator.getRedirectUrl());
         });
+    }
+
+    ngOnInit(): void {
+        this.auth.signIn();
     }
 }

--- a/lib/src/components/asgardeo-sign-in-redirect.component.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.ts
@@ -33,6 +33,7 @@ export class AsgardeoSignInRedirectComponent implements OnInit {
         this.auth.on(Hooks.SignIn, () => {
             this.navigator.navigateByUrl(this.navigator.getRedirectUrl());
         });
+
         this.auth.signIn();
     }
 }

--- a/lib/src/guards/asgardeo-auth.guard.ts
+++ b/lib/src/guards/asgardeo-auth.guard.ts
@@ -32,6 +32,7 @@ export class AsgardeoAuthGuard implements CanActivate, CanActivateChild {
         if (isAuthenticated) {
             return true;
         }
+
         return false;
     }
 

--- a/lib/src/guards/asgardeo-auth.guard.ts
+++ b/lib/src/guards/asgardeo-auth.guard.ts
@@ -25,7 +25,6 @@ import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
     providedIn: "root"
 })
 export class AsgardeoAuthGuard implements CanActivate, CanActivateChild {
-
     constructor(private auth: AsgardeoAuthService) { }
 
     async canActivate(): Promise<boolean> {

--- a/lib/src/interceptors/asgardeo-auth.interceptor.spec.ts
+++ b/lib/src/interceptors/asgardeo-auth.interceptor.spec.ts
@@ -18,15 +18,35 @@
  */
 
 import { TestBed } from "@angular/core/testing";
+import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
+import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoAuthInterceptor } from "./asgardeo-auth.interceptor";
 
 
 describe("AsgardeoAuthInterceptor", () => {
-    beforeEach(() => TestBed.configureTestingModule({
-        providers: [
-            AsgardeoAuthInterceptor
-        ]
-    }));
+    let authService: AsgardeoAuthService;
+    let authServiceStub: Partial<AsgardeoAuthService>;
+
+    beforeEach(() => {
+        authServiceStub = {
+            isAuthenticated: () => Promise.resolve(true)
+        };
+
+        TestBed.configureTestingModule({
+            providers: [
+                AsgardeoAuthInterceptor,
+                {
+                    provide: ASGARDEO_CONFIG,
+                    useValue: {}
+                },
+                {
+                    provide: AsgardeoAuthService,
+                    useValue: authServiceStub
+                }
+            ]
+        })
+        authService = TestBed.inject(AsgardeoAuthService);
+    });
 
     it("should be created", () => {
         const interceptor: AsgardeoAuthInterceptor = TestBed.inject(AsgardeoAuthInterceptor);

--- a/lib/src/interceptors/asgardeo-auth.interceptor.spec.ts
+++ b/lib/src/interceptors/asgardeo-auth.interceptor.spec.ts
@@ -22,7 +22,6 @@ import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoAuthInterceptor } from "./asgardeo-auth.interceptor";
 
-
 describe("AsgardeoAuthInterceptor", () => {
     let authService: AsgardeoAuthService;
     let authServiceStub: Partial<AsgardeoAuthService>;
@@ -44,7 +43,7 @@ describe("AsgardeoAuthInterceptor", () => {
                     useValue: authServiceStub
                 }
             ]
-        })
+        });
         authService = TestBed.inject(AsgardeoAuthService);
     });
 

--- a/lib/src/interceptors/asgardeo-auth.interceptor.spec.ts
+++ b/lib/src/interceptors/asgardeo-auth.interceptor.spec.ts
@@ -1,6 +1,25 @@
-import { TestBed } from "@angular/core/testing";
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
 
+import { TestBed } from "@angular/core/testing";
 import { AsgardeoAuthInterceptor } from "./asgardeo-auth.interceptor";
+
 
 describe("AsgardeoAuthInterceptor", () => {
     beforeEach(() => TestBed.configureTestingModule({

--- a/lib/src/interceptors/asgardeo-auth.interceptor.spec.ts
+++ b/lib/src/interceptors/asgardeo-auth.interceptor.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { AsgardeoAuthInterceptor } from "./asgardeo-auth.interceptor";
+
+describe("AsgardeoAuthInterceptor", () => {
+    beforeEach(() => TestBed.configureTestingModule({
+        providers: [
+            AsgardeoAuthInterceptor
+        ]
+    }));
+
+    it("should be created", () => {
+        const interceptor: AsgardeoAuthInterceptor = TestBed.inject(AsgardeoAuthInterceptor);
+        expect(interceptor).toBeTruthy();
+    });
+});

--- a/lib/src/interceptors/asgardeo-auth.interceptor.ts
+++ b/lib/src/interceptors/asgardeo-auth.interceptor.ts
@@ -19,7 +19,7 @@
 
 import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from "@angular/common/http";
 import { Inject, Injectable } from "@angular/core";
-import { Observable } from "rxjs";
+import { from, Observable } from "rxjs";
 import { catchError, mergeMap } from "rxjs/operators";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
@@ -33,7 +33,7 @@ export class AsgardeoAuthInterceptor implements HttpInterceptor {
 
     intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
         if (this.canAttachToken(request, this.authConfig["resourceServerURLs"])) {
-            return this.auth.getAccessToken()
+            return from(this.auth.getAccessToken())
                 .pipe(
                     mergeMap(token => {
                         if (token) {

--- a/lib/src/interceptors/asgardeo-auth.interceptor.ts
+++ b/lib/src/interceptors/asgardeo-auth.interceptor.ts
@@ -41,10 +41,12 @@ export class AsgardeoAuthInterceptor implements HttpInterceptor {
                             const headers = request.headers.set("Authorization", header);
                             request = request.clone({ headers });
                         }
+
                         return next.handle(request);
                     }),
                     catchError(error => {
                         console.error(error);
+
                         return next.handle(request);
                     }),
                 );
@@ -63,6 +65,7 @@ export class AsgardeoAuthInterceptor implements HttpInterceptor {
                 }
             });
         }
+
         return matches;
     }
 }

--- a/lib/src/interceptors/asgardeo-auth.interceptor.ts
+++ b/lib/src/interceptors/asgardeo-auth.interceptor.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+
+@Injectable()
+export class AsgardeoAuthInterceptor implements HttpInterceptor {
+    constructor() { }
+
+    intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+        return next.handle(request);
+    }
+}

--- a/lib/src/interceptors/asgardeo-auth.interceptor.ts
+++ b/lib/src/interceptors/asgardeo-auth.interceptor.ts
@@ -59,6 +59,5 @@ export class AsgardeoAuthInterceptor implements HttpInterceptor {
         else {
             return false;
         }
-
     }
 }

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -20,5 +20,7 @@
 export {
     BasicUserInfo,
     DecodedIDTokenPayload,
-    OIDCEndpoints
+    Hooks,
+    OIDCEndpoints,
+    SignInConfig
 } from "@asgardeo/auth-spa";

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -17,13 +17,8 @@
  *
  */
 
-/*
- * Public API Surface of @asgardeo/auth-angular
- */
-
-export * from "./asgardeo-auth.module";
-export * from "./components/asgardeo-sign-in-redirect.component";
-export * from "./guards/asgardeo-auth.guard";
-export * from "./models/asgardeo-config.interface";
-export * from "./models/asgardeo-spa.models";
-export * from "./services/asgardeo-auth.service";
+export {
+    BasicUserInfo,
+    DecodedIDTokenPayload,
+    OIDCEndpoints
+} from "@asgardeo/auth-spa";

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -19,7 +19,9 @@
 
 export {
     BasicUserInfo,
+    CustomGrantConfig,
     DecodedIDTokenPayload,
+    HttpResponse,
     OIDCEndpoints,
     SignInConfig
 } from "@asgardeo/auth-spa";

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -20,7 +20,13 @@
 export {
     BasicUserInfo,
     DecodedIDTokenPayload,
-    Hooks,
     OIDCEndpoints,
     SignInConfig
 } from "@asgardeo/auth-spa";
+
+/* eslint-disable */
+export enum Hooks {
+    SignIn = "sign-in",
+    SignOut = "sign-out",
+    RevokeAccessToken = "revoke-access-token"
+}

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -21,15 +21,9 @@ export {
     BasicUserInfo,
     CustomGrantConfig,
     DecodedIDTokenPayload,
+    Hooks,
+    HttpRequestConfig,
     HttpResponse,
     OIDCEndpoints,
     SignInConfig
 } from "@asgardeo/auth-spa";
-
-/* eslint-disable */
-export enum Hooks {
-    SignIn = "sign-in",
-    SignOut = "sign-out",
-    RevokeAccessToken = "revoke-access-token",
-    CustomGrant = "custom-grant"
-}

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -30,5 +30,6 @@ export {
 export enum Hooks {
     SignIn = "sign-in",
     SignOut = "sign-out",
-    RevokeAccessToken = "revoke-access-token"
+    RevokeAccessToken = "revoke-access-token",
+    CustomGrant = "custom-grant"
 }

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -26,5 +26,7 @@ export {
     HttpResponse,
     Method,
     OIDCEndpoints,
-    SignInConfig
+    ResponseMode,
+    SignInConfig,
+    Storage
 } from "@asgardeo/auth-spa";

--- a/lib/src/models/asgardeo-spa.models.ts
+++ b/lib/src/models/asgardeo-spa.models.ts
@@ -24,6 +24,7 @@ export {
     Hooks,
     HttpRequestConfig,
     HttpResponse,
+    Method,
     OIDCEndpoints,
     SignInConfig
 } from "@asgardeo/auth-spa";

--- a/lib/src/public-api.ts
+++ b/lib/src/public-api.ts
@@ -24,6 +24,7 @@
 export * from "./asgardeo-auth.module";
 export * from "./components/asgardeo-sign-in-redirect.component";
 export * from "./guards/asgardeo-auth.guard";
+export * from "./interceptors/asgardeo-auth.interceptor";
 export * from "./models/asgardeo-config.interface";
 export * from "./models/asgardeo-spa.models";
 export * from "./services/asgardeo-auth.service";

--- a/lib/src/services/asgardeo-auth.service.spec.ts
+++ b/lib/src/services/asgardeo-auth.service.spec.ts
@@ -181,5 +181,4 @@ describe("AsgardeoAuthService", () => {
 
         expect(requestCustomGrantSpy).toHaveBeenCalled();
     });
-
 });

--- a/lib/src/services/asgardeo-auth.service.spec.ts
+++ b/lib/src/services/asgardeo-auth.service.spec.ts
@@ -20,7 +20,7 @@
 import { TestBed } from "@angular/core/testing";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
-import { Hooks } from "../models/asgardeo-spa.models";
+import { CustomGrantConfig, Hooks } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "./asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "./asgardeo-navigator.service";
 
@@ -165,4 +165,21 @@ describe("AsgardeoAuthService", () => {
 
         expect(onSpy).toHaveBeenCalled();
     });
+
+    it("should call auth.on when on is called with CustomGrant Hook", () => {
+        const onSpy = spyOn(service["auth"], "on");
+
+        service.on(Hooks.CustomGrant, () => { });
+
+        expect(onSpy).toHaveBeenCalled();
+    });
+
+    it("should call auth.requestCustomGrant when requestCustomGrant is called", () => {
+        const requestCustomGrantSpy = spyOn(service["auth"], "requestCustomGrant");
+
+        service.requestCustomGrant({} as CustomGrantConfig);
+
+        expect(requestCustomGrantSpy).toHaveBeenCalled();
+    });
+
 });

--- a/lib/src/services/asgardeo-auth.service.spec.ts
+++ b/lib/src/services/asgardeo-auth.service.spec.ts
@@ -60,7 +60,6 @@ describe("AsgardeoAuthService", () => {
     it("should be created", () => {
         expect(service).toBeTruthy();
         expect(service["auth"]).toBeDefined();
-        expect();
     });
 
     it("should call auth.signIn when signIn is called", () => {

--- a/lib/src/services/asgardeo-auth.service.spec.ts
+++ b/lib/src/services/asgardeo-auth.service.spec.ts
@@ -32,7 +32,6 @@ describe("AsgardeoAuthService", () => {
     let navigatorServiceStub: Partial<AsgardeoNavigatorService>;
 
     beforeEach(() => {
-
         navigatorServiceStub = {
             navigateByUrl: () => Promise.resolve(true),
             setRedirectUrl: () => "",

--- a/lib/src/services/asgardeo-auth.service.spec.ts
+++ b/lib/src/services/asgardeo-auth.service.spec.ts
@@ -20,6 +20,7 @@
 import { TestBed } from "@angular/core/testing";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
+import { Hooks } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "./asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "./asgardeo-navigator.service";
 
@@ -33,7 +34,7 @@ describe("AsgardeoAuthService", () => {
     beforeEach(() => {
 
         navigatorServiceStub = {
-            navigateByUrl: (params) => Promise.resolve(true),
+            navigateByUrl: () => Promise.resolve(true),
             setRedirectUrl: () => "",
             getCurrentRoute: () => "fakeUrl",
             getRouteWithoutParams: () => "fakeRoute"
@@ -119,6 +120,14 @@ describe("AsgardeoAuthService", () => {
         expect(getAccessTokenSpy).toHaveBeenCalled();
     });
 
+    it("should call auth.getIDToken when getIDToken is called", () => {
+        const getIDTokenSpy = spyOn(service["auth"], "getIDToken");
+
+        service.getIDToken();
+
+        expect(getIDTokenSpy).toHaveBeenCalled();
+    });
+
     it("should call auth.getDecodedIDToken when getDecodedIDToken is called", () => {
         const getDecodedIDTokenSpy = spyOn(service["auth"], "getDecodedIDToken");
 
@@ -149,5 +158,13 @@ describe("AsgardeoAuthService", () => {
         service.revokeAccessToken();
 
         expect(revokeAccessTokenSpy).toHaveBeenCalled();
+    });
+
+    it("should call auth.on when on is called", () => {
+        const onSpy = spyOn(service["auth"], "on");
+
+        service.on(Hooks.SignIn, () => { });
+
+        expect(onSpy).toHaveBeenCalled();
     });
 });

--- a/lib/src/services/asgardeo-auth.service.spec.ts
+++ b/lib/src/services/asgardeo-auth.service.spec.ts
@@ -20,7 +20,7 @@
 import { TestBed } from "@angular/core/testing";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
-import { CustomGrantConfig, Hooks } from "../models/asgardeo-spa.models";
+import { CustomGrantConfig, Hooks, HttpRequestConfig } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "./asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "./asgardeo-navigator.service";
 
@@ -180,5 +180,21 @@ describe("AsgardeoAuthService", () => {
         service.requestCustomGrant({} as CustomGrantConfig);
 
         expect(requestCustomGrantSpy).toHaveBeenCalled();
+    });
+
+    it("should call auth.httpRequest when httpRequest is called", () => {
+        const httpRequestSpy = spyOn(service["auth"], "httpRequest");
+
+        service.httpRequest({} as HttpRequestConfig);
+
+        expect(httpRequestSpy).toHaveBeenCalled();
+    });
+
+    it("should call auth.httpRequestAll when httpRequestAll is called", () => {
+        const httpRequestAllSpy = spyOn(service["auth"], "httpRequestAll");
+
+        service.httpRequestAll({} as HttpRequestConfig[]);
+
+        expect(httpRequestAllSpy).toHaveBeenCalled();
     });
 });

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -93,7 +93,7 @@ export class AsgardeoAuthService {
         return this.auth.revokeAccessToken();
     }
 
-    on(hook: Hooks, callback: (response?: any) => void, id: string): Promise<void> {
+    on(hook: Hooks, callback: (response?: any) => void, id?: string): Promise<void> {
         if (hook === Hooks.CustomGrant) {
             return this.auth.on(hook, callback, id);
         }

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -18,9 +18,10 @@
  */
 
 import { Inject, Injectable } from "@angular/core";
-import { AsgardeoSPAClient, BasicUserInfo, DecodedIDTokenPayload, OIDCEndpoints } from "@asgardeo/auth-spa";
+import { AsgardeoSPAClient } from "@asgardeo/auth-spa";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
+import { BasicUserInfo, DecodedIDTokenPayload, OIDCEndpoints } from "../models/asgardeo-spa.models";
 import { AsgardeoNavigatorService } from "./asgardeo-navigator.service";
 
 @Injectable({

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -41,7 +41,7 @@ export class AsgardeoAuthService {
         authorizationCode?: string,
         sessionState?: string
     ) {
-        this.auth.signIn(config, authorizationCode, sessionState);
+        return this.auth.signIn(config, authorizationCode, sessionState);
     };
 
     signInWithRedirect(): Promise<boolean> {
@@ -87,9 +87,7 @@ export class AsgardeoAuthService {
     }
 
     on(hook: Hooks, callback: (response?: any) => void): Promise<void> {
-        if (hook !== Hooks.CustomGrant) {
-            return this.auth.on(hook, callback);
-        }
+        return this.auth.on(hook, callback);
     };
 
     private intializeSPAClient() {

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -42,7 +42,8 @@ export class AsgardeoAuthService {
     constructor(
         @Inject(ASGARDEO_CONFIG) private authConfig: AsgardeoConfigInterface,
         private navigator: AsgardeoNavigatorService) {
-        this.intializeSPAClient();
+        this.auth = AsgardeoSPAClient.getInstance();
+        this.auth.initialize(this.authConfig);
     }
 
     signIn(
@@ -96,7 +97,7 @@ export class AsgardeoAuthService {
 
     on(hook: Hooks, callback: (response?: any) => void, id?: string): Promise<void> {
         if (hook === Hooks.CustomGrant) {
-            return this.auth.on(hook, callback, id);
+            return this.auth.on(hook, callback, id!);
         }
         return this.auth.on(hook, callback);
     }
@@ -111,10 +112,5 @@ export class AsgardeoAuthService {
 
     httpRequestAll(config: HttpRequestConfig[]): Promise<HttpResponse<any>[]> {
         return this.auth.httpRequestAll(config);
-    }
-
-    private intializeSPAClient() {
-        this.auth = AsgardeoSPAClient.getInstance();
-        this.auth.initialize(this.authConfig);
     }
 }

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -50,7 +50,7 @@ export class AsgardeoAuthService {
         authorizationCode?: string,
         sessionState?: string) {
         return this.auth.signIn(config, authorizationCode, sessionState);
-    };
+    }
 
     signInWithRedirect(): Promise<boolean> {
         this.navigator.setRedirectUrl();
@@ -99,11 +99,11 @@ export class AsgardeoAuthService {
             return this.auth.on(hook, callback, id);
         }
         return this.auth.on(hook, callback);
-    };
+    }
 
     requestCustomGrant(config: CustomGrantConfig): Promise<HttpResponse<any> | BasicUserInfo> {
         return this.auth.requestCustomGrant(config);
-    };
+    }
 
     httpRequest(config: HttpRequestConfig): Promise<HttpResponse<any>> {
         return this.auth.httpRequest(config);

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -21,7 +21,7 @@ import { Inject, Injectable } from "@angular/core";
 import { AsgardeoSPAClient } from "@asgardeo/auth-spa";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
-import { BasicUserInfo, DecodedIDTokenPayload, OIDCEndpoints } from "../models/asgardeo-spa.models";
+import { BasicUserInfo, DecodedIDTokenPayload, Hooks, OIDCEndpoints, SignInConfig } from "../models/asgardeo-spa.models";
 import { AsgardeoNavigatorService } from "./asgardeo-navigator.service";
 
 @Injectable({
@@ -36,9 +36,13 @@ export class AsgardeoAuthService {
         this.intializeSPAClient();
     }
 
-    signIn(): Promise<BasicUserInfo> {
-        return this.auth.signIn();
-    }
+    signIn(
+        config?: SignInConfig,
+        authorizationCode?: string,
+        sessionState?: string
+    ) {
+        this.auth.signIn(config, authorizationCode, sessionState);
+    };
 
     signInWithRedirect(): Promise<boolean> {
         this.navigator.setRedirectUrl();
@@ -81,6 +85,12 @@ export class AsgardeoAuthService {
     revokeAccessToken(): Promise<boolean> {
         return this.auth.revokeAccessToken();
     }
+
+    on(hook: Hooks, callback: (response?: any) => void): Promise<void> {
+        if (hook !== Hooks.CustomGrant) {
+            return this.auth.on(hook, callback);
+        }
+    };
 
     private intializeSPAClient() {
         this.auth = AsgardeoSPAClient.getInstance();

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -26,6 +26,7 @@ import {
     CustomGrantConfig,
     DecodedIDTokenPayload,
     Hooks,
+    HttpRequestConfig,
     HttpResponse,
     OIDCEndpoints,
     SignInConfig
@@ -103,6 +104,14 @@ export class AsgardeoAuthService {
     requestCustomGrant(config: CustomGrantConfig): Promise<HttpResponse<any> | BasicUserInfo> {
         return this.auth.requestCustomGrant(config);
     };
+
+    httpRequest(config: HttpRequestConfig): Promise<HttpResponse<any>> {
+        return this.auth.httpRequest(config);
+    }
+
+    httpRequestAll(config: HttpRequestConfig[]): Promise<HttpResponse<any>[]> {
+        return this.auth.httpRequestAll(config);
+    }
 
     private intializeSPAClient() {
         this.auth = AsgardeoSPAClient.getInstance();

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -93,7 +93,10 @@ export class AsgardeoAuthService {
         return this.auth.revokeAccessToken();
     }
 
-    on(hook: Hooks, callback: (response?: any) => void): Promise<void> {
+    on(hook: Hooks, callback: (response?: any) => void, id: string): Promise<void> {
+        if (hook === Hooks.CustomGrant) {
+            return this.auth.on(hook, callback, id);
+        }
         return this.auth.on(hook, callback);
     };
 

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -21,7 +21,15 @@ import { Inject, Injectable } from "@angular/core";
 import { AsgardeoSPAClient } from "@asgardeo/auth-spa";
 import { ASGARDEO_CONFIG } from "../configs/asgardeo-config";
 import { AsgardeoConfigInterface } from "../models/asgardeo-config.interface";
-import { BasicUserInfo, DecodedIDTokenPayload, Hooks, OIDCEndpoints, SignInConfig } from "../models/asgardeo-spa.models";
+import {
+    BasicUserInfo,
+    CustomGrantConfig,
+    DecodedIDTokenPayload,
+    Hooks,
+    HttpResponse,
+    OIDCEndpoints,
+    SignInConfig
+} from "../models/asgardeo-spa.models";
 import { AsgardeoNavigatorService } from "./asgardeo-navigator.service";
 
 @Injectable({
@@ -39,8 +47,7 @@ export class AsgardeoAuthService {
     signIn(
         config?: SignInConfig,
         authorizationCode?: string,
-        sessionState?: string
-    ) {
+        sessionState?: string) {
         return this.auth.signIn(config, authorizationCode, sessionState);
     };
 
@@ -88,6 +95,10 @@ export class AsgardeoAuthService {
 
     on(hook: Hooks, callback: (response?: any) => void): Promise<void> {
         return this.auth.on(hook, callback);
+    };
+
+    requestCustomGrant(config: CustomGrantConfig): Promise<HttpResponse<any> | BasicUserInfo> {
+        return this.auth.requestCustomGrant(config);
     };
 
     private intializeSPAClient() {

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -46,16 +46,14 @@ export class AsgardeoAuthService {
         this.auth.initialize(this.authConfig);
     }
 
-    signIn(
-        config?: SignInConfig,
-        authorizationCode?: string,
-        sessionState?: string) {
+    signIn(config?: SignInConfig, authorizationCode?: string, sessionState?: string): Promise<BasicUserInfo> {
         return this.auth.signIn(config, authorizationCode, sessionState);
     }
 
     signInWithRedirect(): Promise<boolean> {
         this.navigator.setRedirectUrl();
         const redirectRoute = this.navigator.getRouteWithoutParams(this.authConfig.signInRedirectURL);
+
         return this.navigator.navigateByUrl(redirectRoute);
     }
 
@@ -97,8 +95,9 @@ export class AsgardeoAuthService {
 
     on(hook: Hooks, callback: (response?: any) => void, id?: string): Promise<void> {
         if (hook === Hooks.CustomGrant) {
-            return this.auth.on(hook, callback, id!);
+            return this.auth.on(hook, callback, id as string);
         }
+
         return this.auth.on(hook, callback);
     }
 

--- a/lib/src/services/asgardeo-navigator.service.spec.ts
+++ b/lib/src/services/asgardeo-navigator.service.spec.ts
@@ -31,6 +31,12 @@ describe("AsgardeoNavigatorService", () => {
     it("should be created even if the router module is not provided ", () => {
         expect(service).toBeTruthy();
     });
+
+    it("should return a promise that resolves with false when navigateByUrl is called", async () => {
+        const result = await service.navigateByUrl("fakePath");
+
+        expect(result).toBeFalse();
+    });
 });
 
 describe("AsgardeoNavigatorService", () => {

--- a/lib/src/services/asgardeo-navigator.service.ts
+++ b/lib/src/services/asgardeo-navigator.service.ts
@@ -24,7 +24,6 @@ import { Router } from "@angular/router";
     providedIn: "root"
 })
 export class AsgardeoNavigatorService {
-
     private readonly router: Router;
 
     constructor(injector: Injector) {

--- a/lib/src/services/asgardeo-navigator.service.ts
+++ b/lib/src/services/asgardeo-navigator.service.ts
@@ -24,7 +24,7 @@ import { Router } from "@angular/router";
     providedIn: "root"
 })
 export class AsgardeoNavigatorService {
-    private readonly router: Router;
+    private readonly router?: Router;
 
     constructor(injector: Injector) {
         try {
@@ -36,7 +36,12 @@ export class AsgardeoNavigatorService {
     }
 
     navigateByUrl(url: string): Promise<boolean> {
-        return this.router.navigateByUrl(url);
+        if (this.router) {
+            return this.router.navigateByUrl(url);
+        }
+        else {
+            return Promise.resolve(false);
+        }
     }
 
     setRedirectUrl(): void {
@@ -52,6 +57,11 @@ export class AsgardeoNavigatorService {
     }
 
     getCurrentRoute(): string {
-        return this.router.url.split("?")[0];
+        if (this.router) {
+            return this.router.url.split("?")[0];
+        }
+        else {
+            return window.location.href.split("?")[0];
+        }
     }
 }

--- a/lib/tsconfig.lib.json
+++ b/lib/tsconfig.lib.json
@@ -29,7 +29,8 @@
         "lib": [
             "dom",
             "es2018"
-        ]
+        ],
+        // "strict": true
     },
     "angularCompilerOptions": {
         "skipTemplateCodegen": true,

--- a/playground/src/app/app.component.html
+++ b/playground/src/app/app.component.html
@@ -57,7 +57,7 @@ under the License.
     <footer class="mast-foot mt-auto">
         <div class="inner">
             <p>
-                @2020
+                @2021
                 <a
                     href="https://wso2.com"
                     target="_blank"

--- a/playground/src/app/app.module.ts
+++ b/playground/src/app/app.module.ts
@@ -37,8 +37,8 @@ import { ProfileComponent } from "./profile/profile.component";
         AppRoutingModule,
         HttpClientModule,
         AsgardeoAuthModule.forRoot({
-            signInRedirectURL: "https://localhost:4200/signin/redirect",
-            signOutRedirectURL: "https://localhost:4200",
+            signInRedirectURL: window.location.origin + "/signin/redirect",
+            signOutRedirectURL: window.location.origin,
             clientID: "",
             serverOrigin: "https://localhost:9443",
             scope: ["internal_login"],

--- a/playground/src/app/app.module.ts
+++ b/playground/src/app/app.module.ts
@@ -35,8 +35,8 @@ import { ProfileComponent } from "./profile/profile.component";
         BrowserModule,
         AppRoutingModule,
         AsgardeoAuthModule.forRoot({
-            signInRedirectURL: "https://localhost:3000/signin/redirect",
-            signOutRedirectURL: "https://localhost:3000",
+            signInRedirectURL: "https://localhost:4200/signin/redirect",
+            signOutRedirectURL: "https://localhost:4200",
             clientID: "",
             serverOrigin: ""
         })

--- a/playground/src/app/app.module.ts
+++ b/playground/src/app/app.module.ts
@@ -17,9 +17,10 @@
  *
  */
 
+import { HttpClientModule, HTTP_INTERCEPTORS } from "@angular/common/http";
 import { NgModule } from "@angular/core";
 import { BrowserModule } from "@angular/platform-browser";
-import { AsgardeoAuthModule } from "@asgardeo/auth-angular";
+import { AsgardeoAuthInterceptor, AsgardeoAuthModule } from "@asgardeo/auth-angular";
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
 import { HomeComponent } from "./home/home.component";
@@ -34,14 +35,22 @@ import { ProfileComponent } from "./profile/profile.component";
     imports: [
         BrowserModule,
         AppRoutingModule,
+        HttpClientModule,
         AsgardeoAuthModule.forRoot({
             signInRedirectURL: "https://localhost:4200/signin/redirect",
             signOutRedirectURL: "https://localhost:4200",
             clientID: "",
-            serverOrigin: ""
+            serverOrigin: "https://localhost:9443",
+            scope: ["internal_login"]
         })
     ],
-    providers: [],
+    providers: [
+        {
+            provide: HTTP_INTERCEPTORS,
+            useClass: AsgardeoAuthInterceptor,
+            multi: true
+        }
+    ],
     bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/playground/src/app/app.module.ts
+++ b/playground/src/app/app.module.ts
@@ -41,7 +41,8 @@ import { ProfileComponent } from "./profile/profile.component";
             signOutRedirectURL: "https://localhost:4200",
             clientID: "",
             serverOrigin: "https://localhost:9443",
-            scope: ["internal_login"]
+            scope: ["internal_login"],
+            resourceServerURLs: ["https://localhost:9443/scim2"]
         })
     ],
     providers: [

--- a/playground/src/app/home/home.component.html
+++ b/playground/src/app/home/home.component.html
@@ -39,8 +39,15 @@
             Profile
         </a>
         <a
-            (click)="signOut()"
+            (click)="showHTTPResponse()"
             class="btn cButton cButtonDark"
+        >
+            Send HTTP Request
+        </a>
+        <br />
+        <a
+            (click)="signOut()"
+            class="btn cButton"
         >
             Sign Out
         </a>

--- a/playground/src/app/home/home.component.spec.ts
+++ b/playground/src/app/home/home.component.spec.ts
@@ -18,15 +18,31 @@
  */
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AsgardeoAuthService, BasicUserInfo } from "@asgardeo/auth-angular";
 import { HomeComponent } from "./home.component";
 
 describe("HomeComponent", () => {
     let component: HomeComponent;
     let fixture: ComponentFixture<HomeComponent>;
 
+    let authService: AsgardeoAuthService;
+    let authServiceStub: Partial<AsgardeoAuthService>;
+
+    authServiceStub = {
+        signIn: () => Promise.resolve({} as BasicUserInfo),
+        isAuthenticated: () => Promise.resolve(true),
+        on: () => Promise.resolve()
+    };
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [HomeComponent]
+            declarations: [HomeComponent],
+            providers: [
+                {
+                    provide: AsgardeoAuthService,
+                    useValue: authServiceStub
+                }
+            ]
         })
             .compileComponents();
     });
@@ -34,6 +50,8 @@ describe("HomeComponent", () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(HomeComponent);
         component = fixture.componentInstance;
+
+        authService = TestBed.inject(AsgardeoAuthService);
         fixture.detectChanges();
     });
 

--- a/playground/src/app/home/home.component.spec.ts
+++ b/playground/src/app/home/home.component.spec.ts
@@ -17,6 +17,7 @@
  *
  */
 
+import { HttpClient } from "@angular/common/http";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { AsgardeoAuthService, BasicUserInfo } from "@asgardeo/auth-angular";
 import { HomeComponent } from "./home.component";
@@ -28,6 +29,9 @@ describe("HomeComponent", () => {
     let authService: AsgardeoAuthService;
     let authServiceStub: Partial<AsgardeoAuthService>;
 
+    let httpClient: HttpClient;
+    let httpClientStub: Partial<HttpClient>;
+
     beforeEach(async () => {
         authServiceStub = {
             signIn: () => Promise.resolve({} as BasicUserInfo),
@@ -35,12 +39,18 @@ describe("HomeComponent", () => {
             on: () => Promise.resolve()
         };
 
+        httpClientStub = {};
+
         await TestBed.configureTestingModule({
             declarations: [HomeComponent],
             providers: [
                 {
                     provide: AsgardeoAuthService,
                     useValue: authServiceStub
+                },
+                {
+                    provide: HttpClient,
+                    useValue: httpClientStub
                 }
             ]
         })
@@ -52,6 +62,7 @@ describe("HomeComponent", () => {
         component = fixture.componentInstance;
 
         authService = TestBed.inject(AsgardeoAuthService);
+        httpClient = TestBed.inject(HttpClient);
         fixture.detectChanges();
     });
 

--- a/playground/src/app/home/home.component.spec.ts
+++ b/playground/src/app/home/home.component.spec.ts
@@ -28,13 +28,13 @@ describe("HomeComponent", () => {
     let authService: AsgardeoAuthService;
     let authServiceStub: Partial<AsgardeoAuthService>;
 
-    authServiceStub = {
-        signIn: () => Promise.resolve({} as BasicUserInfo),
-        isAuthenticated: () => Promise.resolve(true),
-        on: () => Promise.resolve()
-    };
-
     beforeEach(async () => {
+        authServiceStub = {
+            signIn: () => Promise.resolve({} as BasicUserInfo),
+            isAuthenticated: () => Promise.resolve(true),
+            on: () => Promise.resolve()
+        };
+
         await TestBed.configureTestingModule({
             declarations: [HomeComponent],
             providers: [

--- a/playground/src/app/home/home.component.ts
+++ b/playground/src/app/home/home.component.ts
@@ -18,7 +18,7 @@
  */
 import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Component, OnInit } from "@angular/core";
-import { AsgardeoAuthService, Hooks } from "@asgardeo/auth-angular";
+import { AsgardeoAuthService, Hooks, Method } from "@asgardeo/auth-angular";
 import { Observable } from "rxjs";
 
 @Component({
@@ -61,8 +61,25 @@ export class HomeComponent implements OnInit {
         return this.http.get(url, httpOptions);
     }
 
+    /* eslint-disable */
+    sendHTTPRequestWithSDK(): Promise<any> {
+        const requestConfig = {
+            headers: {
+                "Accept": "application/json",
+                "Content-Type": "application/scim+json",
+            },
+            method: "GET" as Method,
+            url: "https://localhost:9443/scim2/Me"
+        };
+        return this.auth.httpRequest(requestConfig);
+    }
+
     showHTTPResponse() {
-        this.sendHTTPRequest().subscribe((response) => {
+        // this.sendHTTPRequest().subscribe((response) => {
+        //     console.log(response);
+        // });
+
+        this.sendHTTPRequestWithSDK().then((response) => {
             console.log(response);
         });
     }

--- a/playground/src/app/home/home.component.ts
+++ b/playground/src/app/home/home.component.ts
@@ -75,12 +75,12 @@ export class HomeComponent implements OnInit {
     }
 
     showHTTPResponse() {
-        // this.sendHTTPRequest().subscribe((response) => {
-        //     console.log(response);
-        // });
-
-        this.sendHTTPRequestWithSDK().then((response) => {
+        this.sendHTTPRequest().subscribe((response) => {
             console.log(response);
         });
+
+        // this.sendHTTPRequestWithSDK().then((response) => {
+        //     console.log(response);
+        // });
     }
 }

--- a/playground/src/app/home/home.component.ts
+++ b/playground/src/app/home/home.component.ts
@@ -35,7 +35,7 @@ export class HomeComponent implements OnInit {
         });
     }
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.auth.isAuthenticated().then((status) => {
             this.isAuthenticated = status;
         });
@@ -49,32 +49,32 @@ export class HomeComponent implements OnInit {
         this.auth.signOut();
     }
 
-    /* eslint-disable */
     sendHTTPRequest(): Observable<any> {
         const url = "https://localhost:9443/scim2/Me";
         const httpOptions = {
             headers: new HttpHeaders({
-                "Accept": "application/json",
+                Accept: "application/json",
                 "Content-Type": "application/scim+json",
             })
         };
+
         return this.http.get(url, httpOptions);
     }
 
-    /* eslint-disable */
     sendHTTPRequestWithSDK(): Promise<any> {
         const requestConfig = {
             headers: {
-                "Accept": "application/json",
+                Accept: "application/json",
                 "Content-Type": "application/scim+json",
             },
             method: "GET" as Method,
             url: "https://localhost:9443/scim2/Me"
         };
+
         return this.auth.httpRequest(requestConfig);
     }
 
-    showHTTPResponse() {
+    showHTTPResponse(): void {
         this.sendHTTPRequest().subscribe((response) => {
             console.log(response);
         });

--- a/playground/src/app/home/home.component.ts
+++ b/playground/src/app/home/home.component.ts
@@ -16,9 +16,10 @@
  * under the License.
  *
  */
-
+import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Component, OnInit } from "@angular/core";
 import { AsgardeoAuthService, Hooks } from "@asgardeo/auth-angular";
+import { Observable } from "rxjs";
 
 @Component({
     selector: "app-home",
@@ -28,7 +29,7 @@ import { AsgardeoAuthService, Hooks } from "@asgardeo/auth-angular";
 export class HomeComponent implements OnInit {
     isAuthenticated = false;
 
-    constructor(private auth: AsgardeoAuthService) {
+    constructor(private auth: AsgardeoAuthService, private http: HttpClient) {
         this.auth.on(Hooks.SignOut, () => {
             console.log("You signed out!!!");
         });
@@ -46,5 +47,23 @@ export class HomeComponent implements OnInit {
 
     signOut(): void {
         this.auth.signOut();
+    }
+
+    /* eslint-disable */
+    sendHTTPRequest(): Observable<any> {
+        const url = "https://localhost:9443/scim2/Me";
+        const httpOptions = {
+            headers: new HttpHeaders({
+                "Accept": "application/json",
+                "Content-Type": "application/scim+json",
+            })
+        };
+        return this.http.get(url, httpOptions);
+    }
+
+    showHTTPResponse() {
+        this.sendHTTPRequest().subscribe((response) => {
+            console.log(response);
+        });
     }
 }

--- a/playground/src/app/home/home.component.ts
+++ b/playground/src/app/home/home.component.ts
@@ -18,7 +18,7 @@
  */
 
 import { Component, OnInit } from "@angular/core";
-import { AsgardeoAuthService } from "@asgardeo/auth-angular";
+import { AsgardeoAuthService, Hooks } from "@asgardeo/auth-angular";
 
 @Component({
     selector: "app-home",
@@ -28,7 +28,11 @@ import { AsgardeoAuthService } from "@asgardeo/auth-angular";
 export class HomeComponent implements OnInit {
     isAuthenticated = false;
 
-    constructor(private auth: AsgardeoAuthService) { }
+    constructor(private auth: AsgardeoAuthService) {
+        this.auth.on(Hooks.SignOut, () => {
+            console.log("You signed out!!!");
+        });
+    }
 
     ngOnInit() {
         this.auth.isAuthenticated().then((status) => {

--- a/playground/src/app/profile/profile.component.html
+++ b/playground/src/app/profile/profile.component.html
@@ -31,17 +31,24 @@
             style="width: fit-content;"
         >
             <div class="card-header">
-                <h3>{{userInfo.displayName}}</h3>
+                <h3>{{userInfo.username}}</h3>
             </div>
             <div
                 class="card-body"
                 style="text-align: left;"
             >
-                <li>Access Token - {{accessToken}}</li>
-                <!-- <li>Email - {{userInfo.email}}</li> -->
-                <li>Username - {{userInfo.username}}</li>
-                <li>Allowed Scopes - {{userInfo.allowedScopes}}</li>
-                <li>Tenant Domain - {{userInfo.tenantDomain}}</li>
+                <table>
+                    <tr>
+                        <td>accessToken</td>
+                        <td> - </td>
+                        <td>{{accessToken}}</td>
+                    </tr>
+                    <tr *ngFor="let item of userInfo | keyvalue">
+                        <td>{{item.key}}</td>
+                        <td> - </td>
+                        <td>{{item.value}}</td>
+                    </tr>
+                </table>
             </div>
         </div>
     </ng-template>

--- a/playground/src/app/profile/profile.component.spec.ts
+++ b/playground/src/app/profile/profile.component.spec.ts
@@ -28,12 +28,12 @@ describe("ProfileComponent", () => {
     let authService: AsgardeoAuthService;
     let authServiceStub: Partial<AsgardeoAuthService>;
 
-    authServiceStub = {
-        signIn: () => Promise.resolve({} as BasicUserInfo),
-        isAuthenticated: () => Promise.resolve(true)
-    };
-
     beforeEach(async () => {
+        authServiceStub = {
+            signIn: () => Promise.resolve({} as BasicUserInfo),
+            isAuthenticated: () => Promise.resolve(true)
+        };
+
         await TestBed.configureTestingModule({
             declarations: [ProfileComponent],
             providers: [

--- a/playground/src/app/profile/profile.component.spec.ts
+++ b/playground/src/app/profile/profile.component.spec.ts
@@ -18,15 +18,30 @@
  */
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { AsgardeoAuthService, BasicUserInfo } from "@asgardeo/auth-angular";
 import { ProfileComponent } from "./profile.component";
 
 describe("ProfileComponent", () => {
     let component: ProfileComponent;
     let fixture: ComponentFixture<ProfileComponent>;
 
+    let authService: AsgardeoAuthService;
+    let authServiceStub: Partial<AsgardeoAuthService>;
+
+    authServiceStub = {
+        signIn: () => Promise.resolve({} as BasicUserInfo),
+        isAuthenticated: () => Promise.resolve(true)
+    };
+
     beforeEach(async () => {
         await TestBed.configureTestingModule({
-            declarations: [ProfileComponent]
+            declarations: [ProfileComponent],
+            providers: [
+                {
+                    provide: AsgardeoAuthService,
+                    useValue: authServiceStub
+                }
+            ]
         })
             .compileComponents();
     });
@@ -34,6 +49,8 @@ describe("ProfileComponent", () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ProfileComponent);
         component = fixture.componentInstance;
+
+        authService = TestBed.inject(AsgardeoAuthService);
         fixture.detectChanges();
     });
 

--- a/playground/src/app/profile/profile.component.ts
+++ b/playground/src/app/profile/profile.component.ts
@@ -32,7 +32,7 @@ export class ProfileComponent implements OnInit {
 
     constructor(private auth: AsgardeoAuthService) { }
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.auth.isAuthenticated().then((status) => {
             this.isAuthenticated = status;
             if (this.isAuthenticated) {


### PR DESCRIPTION
## Purpose

- Add a HTTP Interceptor using utilizing the [HTTPInterceptor](https://angular.io/api/common/http/HttpInterceptor) interface of the [@angular/common/http](https://angular.io/api/common/http) entry point.
- Expose [htttpRequest](https://github.com/asgardeo/asgardeo-auth-spa-sdk#httpRequest) and [httpRequestAll](https://github.com/asgardeo/asgardeo-auth-spa-sdk#httprequestall) methods of @asgardeo/auth-spa
- Update playground app

## Goals

Resolves #66 

Closes #70, closes #73

## Automation tests

 - Unit tests  - [Code Coverage](https://janithgan.github.io/asgardeo-auth-angular-sdk/)

## Test environment

- Jasmine / Karma