### PR TITLE
Adds ability to listen to URL params and auto login + Get loading state from the SDK

### DIFF
--- a/lib/src/models/asgardeo-config.interface.ts
+++ b/lib/src/models/asgardeo-config.interface.ts
@@ -14,11 +14,47 @@
  * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
- *
  */
-import { AuthClientConfig, Config } from "@asgardeo/auth-spa";
+
+import { AuthClientConfig, Config, SPAConfig } from "@asgardeo/auth-spa";
 
 /**
  * SDK client config parameters
  */
 export type AsgardeoConfigInterface = AuthClientConfig<Config>;
+
+export interface AuthAngularConfig extends SPAConfig {
+    /**
+     * The SDK's `AuthProvider` by default is listening to the URL changes to see
+     * if `code` & `session_state` search params are available so that it could perform
+     * token exchange. This option could be used to override that behaviour.
+     */
+    skipRedirectCallback?: boolean;
+}
+
+export interface AuthStateInterface {
+    /**
+     * Scopes in the Token.
+     */
+    allowedScopes: string;
+    /**
+     * Displayname.
+     */
+    displayName?: string;
+    /**
+     * User's email.
+     */
+    email?: string;
+    /**
+     * Authenticated state.
+     */
+    isAuthenticated: boolean;
+    /**
+     * Are the Auth requests loading.
+     */
+    isLoading: boolean;
+    /**
+     * Username.
+     */
+    username: string;
+}

--- a/lib/src/models/index.ts
+++ b/lib/src/models/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export * from "./asgardeo-config.interface";

--- a/lib/src/services/asgardeo-auth-state-store.service.ts
+++ b/lib/src/services/asgardeo-auth-state-store.service.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+import { Injectable } from "@angular/core";
+import { AuthStateInterface } from "../models";
+import { BehaviorSubject } from "rxjs";
+
+@Injectable({
+    providedIn: "root"
+})
+export class AsgardeoAuthStateStoreService {
+
+    // Readonly State BehaviorSubject. Not accessible from outside.
+    private readonly _state = new BehaviorSubject<AuthStateInterface>({
+        allowedScopes: "",
+        displayName: "",
+        email: "",
+        isAuthenticated: false,
+        isLoading: true,
+        username: ""
+    });
+
+    // Outside can access this readonly state object by subscribing.
+    readonly state$ = this._state.asObservable();
+
+    /**
+     * Getter for the state.
+     * @return {AuthStateInterface}
+     */
+    public get state(): AuthStateInterface {
+
+        return this._state.getValue();
+    }
+
+    /**
+     * Setter for the state.
+     * @param {AuthStateInterface} newState - New state.
+     */
+    public set state(newState: AuthStateInterface) {
+        this._state.next({
+            ...this._state,
+            ...newState
+        });
+    }
+
+    /**
+     * Set the Loading state.
+     * @param {boolean} isLoading - State.
+     */
+    public setIsLoading(isLoading: boolean): void {
+        this._state.next({
+            ...this.state,
+            isLoading
+        });
+    }
+}


### PR DESCRIPTION
## Purpose
ATM, when integrating the SDK, consumers has to manually call the `SignIn` method when the authorization code is received.
Also there should be a way to get the loading state from the SDK.

## Goals
This PR adds ability to listen to URL changes and auto login and also to retrieve loading state.

## Approach
**Auto Login**
Simply call the `signIn()` method on login button click.

**Override Listening to URL Params**

```ts
AsgardeoAuthModule.forRoot({
        ...
        skipRedirectCallback: true
})
```

**Get Loading state**

```ts
constructor(private auth: AsgardeoAuthService) {
}

this.auth.state$.subscribe(
    (state: AuthStateInterface) => {
         this.loading = state.isLoading;
    }
 })
```