### PR TITLE
Add `sub` attribute to Authenticated state

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,6 +784,7 @@ Of the four methods, storing the session information in the **web worker** is th
 | `allowedScopes` | `string` | The scopes allowed for the user.                                                                   |
 | `tenantDomain`  | `string` | The tenant domain to which the user belongs.                                                       |
 | `sessionState`  | `string` | The session state.                                                                                 |
+| `sub`           | `string` | The `uid` corresponding to the user to whom the ID token belongs to.                               |
 
 ### SignInConfig
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -25,6 +25,6 @@
     },
     "dependencies": {
         "tslib": "^2.0.0",
-        "@asgardeo/auth-spa": "^0.2.11"
+        "@asgardeo/auth-spa": "^0.2.14"
     }
 }

--- a/lib/src/models/asgardeo-config.interface.ts
+++ b/lib/src/models/asgardeo-config.interface.ts
@@ -32,6 +32,10 @@ export interface AuthAngularConfig extends SPAConfig {
     skipRedirectCallback?: boolean;
 }
 
+/**
+ * Interface for the Authenticated state of the user which is exposed
+ * via `state` object.
+ */
 export interface AuthStateInterface {
     /**
      * Scopes in the Token.
@@ -53,6 +57,10 @@ export interface AuthStateInterface {
      * Are the Auth requests loading.
      */
     isLoading: boolean;
+    /**
+     * The `uid` corresponding to whom the ID token belongs to.
+     */
+    sub?: string;
     /**
      * Username.
      */

--- a/lib/src/services/asgardeo-auth-state-store.service.ts
+++ b/lib/src/services/asgardeo-auth-state-store.service.ts
@@ -32,6 +32,7 @@ export class AsgardeoAuthStateStoreService {
         email: "",
         isAuthenticated: false,
         isLoading: true,
+        sub: "",
         username: ""
     };
 

--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -87,8 +87,9 @@ export class AsgardeoAuthService implements OnDestroy {
                         displayName: response.displayName,
                         email: response.email,
                         isAuthenticated: true,
-                        username: response.username,
-                        isLoading: false
+                        isLoading: false,
+                        sub: response.sub,
+                        username: response.username
                     };
                 }
 
@@ -226,6 +227,7 @@ export class AsgardeoAuthService implements OnDestroy {
                         email: basicUserInfo.email,
                         isAuthenticated: true,
                         isLoading: false,
+                        sub: basicUserInfo.sub,
                         username: basicUserInfo.username
                     };
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -594,9 +594,9 @@
             }
         },
         "@asgardeo/auth-js": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/@asgardeo/auth-js/-/auth-js-0.2.15.tgz",
-            "integrity": "sha512-5xtIcAv4EojiVHasUHg2ZwZHdMfjddeOHkbUnmY9VdInEQw2Sq1Jq5TQtNYqv234DaAR6l6ICdsbKQHAMWd8cA==",
+            "version": "0.2.18",
+            "resolved": "https://registry.npmjs.org/@asgardeo/auth-js/-/auth-js-0.2.18.tgz",
+            "integrity": "sha512-qJtOttRXdJ+uiDKfUuzSOU5Ty3/VfCVXSmcCq+8WVyYSr4o7twCBKK6ZwWW0ixqJ4xCczJrGa5ozzeVL+gN20A==",
             "requires": {
                 "base64url": "^3.0.1",
                 "fast-sha256": "^1.3.0",
@@ -605,11 +605,11 @@
             }
         },
         "@asgardeo/auth-spa": {
-            "version": "0.2.11",
-            "resolved": "https://registry.npmjs.org/@asgardeo/auth-spa/-/auth-spa-0.2.11.tgz",
-            "integrity": "sha512-FOkD1teZqD5LdNhamy7e4eVmblioj1+/PqAVWoFL+Kb2aNz/er6pdtt1v6qf50WYRHXWl52QEdwaQCzUS2PCrQ==",
+            "version": "0.2.14",
+            "resolved": "https://registry.npmjs.org/@asgardeo/auth-spa/-/auth-spa-0.2.14.tgz",
+            "integrity": "sha512-sHUHve7tQ5DJPJmV4ZURwCSAUnzE5/CdHya02CnL4LYTSDdGyZKYRkeEruetbfRFdSB8cVG/k5mbLK1TXP9YvQ==",
             "requires": {
-                "@asgardeo/auth-js": "^0.2.15",
+                "@asgardeo/auth-js": "^0.2.18",
                 "@babel/runtime-corejs3": "^7.11.2",
                 "await-semaphore": "^0.1.3",
                 "axios": "^0.21.0",
@@ -3211,9 +3211,9 @@
             },
             "dependencies": {
                 "follow-redirects": {
-                    "version": "1.14.4",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-                    "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+                    "version": "1.14.5",
+                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+                    "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
                 }
             }
         },
@@ -8208,9 +8208,9 @@
             }
         },
         "jose": {
-            "version": "3.20.1",
-            "resolved": "https://registry.npmjs.org/jose/-/jose-3.20.1.tgz",
-            "integrity": "sha512-qAO8uCyyOfkpsAWL4U0O1ug/N8Y4OgYFMvIsvlhU1vcahUcvYkH1MOgN0JIr+XqR9O9A36NwCPju6sPHy8P6jg=="
+            "version": "3.20.3",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-3.20.3.tgz",
+            "integrity": "sha512-Z4a5Nl4pmGivdSgaq+a5EbNjrvSO4vtBTmVy5C3HNxWfJ92aG8DTNZrQywowxyOlSqdX/BmCPAy/ieElXDM3pw=="
         },
         "js-tokens": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "@angular/platform-browser": "~10.2.4",
         "@angular/platform-browser-dynamic": "~10.2.4",
         "@angular/router": "~10.2.4",
-        "@asgardeo/auth-spa": "^0.2.11",
+        "@asgardeo/auth-spa": "^0.2.14",
         "rxjs": "~6.6.0",
         "tslib": "^2.1.0",
         "zone.js": "~0.10.2"


### PR DESCRIPTION
## Purpose
Bring in changes done in https://github.com/asgardeo/asgardeo-auth-js-sdk/pull/163 & https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/64 to enable returning the `sub` from the `id_token` as a high level item via the Authenticated State.

## Goals
Fixes https://github.com/asgardeo/asgardeo-auth-react-sdk/issues/64

## Approach
Refer https://github.com/asgardeo/asgardeo-auth-js-sdk/pull/163 & https://github.com/asgardeo/asgardeo-auth-spa-sdk/pull/64

## User stories
None

## Release note
None

## Documentation
None

## Training
None

## Certification
None

## Marketing
None

## Automation tests
None

## Security checks
None

## Samples
None

## Related PRs
None

## Migrations (if applicable)
None

## Test environment
None
 
## Learning
None