### PR TITLE
Fixed Issue With Clearing User Session Data on Sign-out 

### DIFF
--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -58,7 +58,7 @@ export class AsgardeoAuthService implements OnDestroy {
     ) {
         this.config = authConfig;
         this.auth = AsgardeoSPAClient.getInstance();
-
+        this.initializeHooks();
         (async (): Promise<void> => {
             await this.auth.initialize(this.authConfig);
             this.handleAutoLogin()
@@ -74,6 +74,13 @@ export class AsgardeoAuthService implements OnDestroy {
     ngOnDestroy(): void {
         this.subscriptionDestroyer$.next(true);
         this.subscriptionDestroyer$.unsubscribe();
+    }
+
+    /**
+     * Registering a sign-out hook clears user session data internally if there was a successful logout.
+     */
+    initializeHooks(): void {
+        this.auth.on(Hooks.SignOut, ()=>{});
     }
 
     signIn(


### PR DESCRIPTION
## Purpose
> Fixes the issue https://github.com/asgardeo/asgardeo-auth-angular-sdk/issues/115

## Approach
> Registering a sign-out hook for the application when the AsgardeoAuthService initializes. This will internally clear out the  user session data inside the on( ) method if there have been a successful sign-out.