### PR TITLE
Implement a method to handle single logout on redirect.

### DIFF
--- a/lib/src/services/asgardeo-auth.service.ts
+++ b/lib/src/services/asgardeo-auth.service.ts
@@ -61,6 +61,7 @@ export class AsgardeoAuthService implements OnDestroy {
 
         (async (): Promise<void> => {
             await this.auth.initialize(this.authConfig);
+            await this.handleSingleLogoutOnRedirect();
             this.handleAutoLogin()
                 .pipe(takeUntil(this.subscriptionDestroyer$))
                 .subscribe();
@@ -273,5 +274,20 @@ export class AsgardeoAuthService implements OnDestroy {
         // This uses the RP iframe to get the session. Hence, will not work if 3rd party cookies are disabled.
         // If the browser has these cookies disabled, we'll not be able to retrieve the session on refreshes.
         return from(this.trySignInSilently());
+    }
+
+    /**
+     * Handles single logout if a prompt none sign in response is received with an error parameter on the URL.
+     *
+     * @private
+     * @return {Promise<BasicUserInfo | void>}
+     */
+    private async handleSingleLogoutOnRedirect(): Promise<BasicUserInfo | void> {
+
+        if (SPAUtils.hasErrorInURL()) {
+            // The signIn method call will call receivePromptNoneResponse method internally to handle the prompt none
+            // response in the single logout flow.
+            return this.signIn({callOnlyOnRedirect: true});
+        }
     }
 }


### PR DESCRIPTION
## Purpose
> In the single logout flow, the `receivePromptNoneResponse()` method should be called after receiving a `prompt = none` response with an error parameter in the URL to trigger the logout request. Since this is not implemented in the auth angular SDK, the logout request in the single logout flow does not get triggered. The purpose of this PR is to fix this issue.

## Approach
> The `signIn()` method has been called with `callOnlyOnRedirect: true` when the auth service component is initialized because the `receivePromptNoneResponse()` method is called internally by the `signIn()` method.
