### PR TITLE
Fix the login loop when signing in after configuring angular router.

### DIFF
--- a/lib/src/components/asgardeo-sign-in-redirect.component.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.ts
@@ -21,6 +21,7 @@ import { Component, OnInit } from "@angular/core";
 import { Hooks } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service";
+import {SPAUtils} from "@asgardeo/auth-spa";
 
 @Component({
     selector: "lib-asgardeo-sign-in-redirect",
@@ -34,6 +35,8 @@ export class AsgardeoSignInRedirectComponent implements OnInit {
             this.navigator.navigateByUrl(this.navigator.getRedirectUrl());
         });
 
-        this.auth.signIn();
+        if (!SPAUtils.hasAuthSearchParamsInURL(this.navigator.getCurrentUrl())) {
+            this.auth.signIn();
+        }
     }
 }

--- a/lib/src/components/asgardeo-sign-in-redirect.component.ts
+++ b/lib/src/components/asgardeo-sign-in-redirect.component.ts
@@ -21,7 +21,7 @@ import { Component, OnInit } from "@angular/core";
 import { Hooks } from "../models/asgardeo-spa.models";
 import { AsgardeoAuthService } from "../services/asgardeo-auth.service";
 import { AsgardeoNavigatorService } from "../services/asgardeo-navigator.service";
-import {SPAUtils} from "@asgardeo/auth-spa";
+import { SPAUtils } from "@asgardeo/auth-spa";
 
 @Component({
     selector: "lib-asgardeo-sign-in-redirect",

--- a/lib/src/services/asgardeo-navigator.service.ts
+++ b/lib/src/services/asgardeo-navigator.service.ts
@@ -64,4 +64,13 @@ export class AsgardeoNavigatorService {
             return window.location.href.split("?")[0];
         }
     }
+
+    getCurrentUrl(): string {
+        if (this.router) {
+            return this.router.url;
+        } else {
+            return window.location.href;
+        }
+
+    }
 }


### PR DESCRIPTION
## Purpose
> Fixes https://github.com/asgardeo/asgardeo-auth-angular-sdk/issues/122

## Approach
> The reason for the login loop is that the `AsgardeoSignInRedirectComponent` contains a `signIn()`method call inside the `ngOnInit()` method in order to get `signInWithRedirect()` method working. However, when Asgardeo redirect user back to the `signInRedirectURL` after login in, this `signIn()` method will be called again since `ngOnInit()` executes on every initilization of `AsgardeoSignInRedirectComponent`. 
>
> An additional check has been added before calling `signIn()` to skip the method call if the `ngOnInit()` method has been called on a redirect to resolve the issue.

